### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 graphtools
 numpy
 pandas
+scprep @ git+https://github.com/jamisonorton/scprep
 phate
 scikit_learn
 scipy


### PR DESCRIPTION
Adding Jamison's fork of scprep (that doesn't specify an old version of pandas) as a dependency before installing phate so that M1/M2 Mac users can install the package.